### PR TITLE
Fix package.json BOM causing build failure

### DIFF
--- a/build-app.ps1
+++ b/build-app.ps1
@@ -1,4 +1,4 @@
-﻿# Script de build pour SyncOtter
+# Script de build pour SyncOtter
 param(
     [switch]$Clean = $true,
     [switch]$InstallDeps = $false,

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "name":  "syncotter",
     "version":  "1.0.0",
     "description":  "Outil de synchronisation intelligent avec loutre",


### PR DESCRIPTION
## Summary
- remove UTF-8 BOM from `package.json`
- remove BOM from `build-app.ps1`

These BOM characters caused `electron-builder` to fail with `Error reading package.json` on Windows. Removing them allows the build scripts to parse the files properly.

## Testing
- `git status --short`