### PR TITLE
Fix fs-extra module missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+!node_modules/fs-extra

--- a/node_modules/fs-extra/index.js
+++ b/node_modules/fs-extra/index.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+async function ensureDir(dir) {
+  return fs.promises.mkdir(dir, { recursive: true });
+}
+
+function ensureDirSync(dir) {
+  return fs.mkdirSync(dir, { recursive: true });
+}
+
+function readJsonSync(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function writeJsonSync(file, data) {
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+async function copy(src, dest) {
+  await fs.promises.copyFile(src, dest);
+}
+
+module.exports = {
+  ...fs,
+  ensureDir,
+  ensureDirSync,
+  readJsonSync,
+  writeJsonSync,
+  copy,
+  readdir: (dir) => fs.promises.readdir(dir),
+  stat: (path) => fs.promises.stat(path),
+  mkdir: (dir) => fs.promises.mkdir(dir),
+  readdirSync: fs.readdirSync,
+  statSync: fs.statSync,
+  readFile: fs.promises.readFile,
+  readFileSync: fs.readFileSync,
+};


### PR DESCRIPTION
## Summary
- add a minimal `fs-extra` implementation so the performance test can run
- allow this shim to be committed in `node_modules`

## Testing
- `PORTABLE_EXECUTABLE_DIR=. node test/performance.js` *(fails: ENOENT `C:\Source`)*