### PR TITLE
Fix IPC reliability and add graceful shutdown

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,40 +30,68 @@ let telemetry;
 const analytics = new AnalyticsEngine();
 const reportGenerator = new ReportGenerator();
 const logger = new AdvancedLogger();
+let shuttingDown = false;
+
+process.on('SIGINT', gracefulShutdown);
+process.on('SIGTERM', gracefulShutdown);
+app.on('before-quit', gracefulShutdown);
+
+function safeSend(channel, data, attempt = 0) {
+  try {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(channel, data);
+      return;
+    }
+  } catch (err) {
+    logger.log('error', `IPC send failed on ${channel}: ${err.message}`);
+  }
+  if (attempt < 3) {
+    setTimeout(() => safeSend(channel, data, attempt + 1), 300);
+  }
+}
+
+async function gracefulShutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  try {
+    safeSend('update-status', 'Fermeture...');
+    await CacheManager.saveCache();
+  } catch (err) {
+    logger.log('error', `Graceful shutdown failed: ${err.message}`);
+  }
+  app.quit();
+}
 
 // Vérifier et tuer les processus SyncOtter existants
 async function killExistingProcesses() {
   return new Promise((resolve) => {
     const currentPid = process.pid;
+    const exePath = process.execPath.toLowerCase();
 
-    exec('tasklist /FI "IMAGENAME eq SyncOtter*" /FO CSV', (error, stdout) => {
-      if (error || !stdout.includes('SyncOtter')) {
-        resolve(false); // Pas de processus existant
+    exec('wmic process where "name like \"SyncOtter%\"" get ProcessId,ExecutablePath /FORMAT:CSV', (error, stdout) => {
+      if (error || !stdout) {
+        resolve(false);
         return;
       }
 
-      // Parser la sortie CSV pour extraire les PIDs
-      const lines = stdout.split('\n').slice(1); // Ignorer l'en-tête
+      const lines = stdout.trim().split(/\r?\n/).slice(1);
       const processes = lines
-        .filter(line => line.includes('SyncOtter'))
         .map(line => {
-          const parts = line.split('\",\"');
-          return {
-            name: parts[0]?.replace('"', ''),
-            pid: parseInt(parts[1]) || 0
-          };
+          const parts = line.split(',');
+          const pid = parseInt(parts[2], 10);
+          const pathExe = (parts[1] || '').trim().toLowerCase();
+          return { pid, path: pathExe };
         })
-        .filter(proc => proc.pid && proc.pid !== currentPid); // Exclure le processus actuel
+        .filter(p => p.pid && p.pid !== currentPid && p.path === exePath);
 
       if (processes.length === 0) {
-        resolve(false); // Pas d'autres processus
+        resolve(false);
         return;
       }
 
       console.log('🔄 SyncOtter déjà en cours, arrêt des processus existants...');
       logger.log('info', 'Instance existante détectée, arrêt en cours');
 
-      // Tuer seulement les autres processus
       const pidsToKill = processes.map(p => p.pid).join(' ');
       exec(`taskkill /F /PID ${pidsToKill}`, (killError) => {
         if (!killError) {
@@ -138,7 +166,7 @@ async function loadConfig() {
       console.error('💡 Solution: Placez config.json à côté de l\'exe SyncOtter');
     }
 
-    app.quit();
+    gracefulShutdown();
   }
 }
 
@@ -161,6 +189,11 @@ function createSplashWindow() {
   mainWindow.loadFile(path.join(__dirname, 'splash.html'));
   mainWindow.once('ready-to-show', () => {
     mainWindow.show();
+    safeSend('app-info', {
+      appName: config.appName,
+      appDescription: config.appDescription,
+      executeAfterSync: config.executeAfterSync
+    });
   });
 }
 
@@ -234,20 +267,32 @@ async function performSync() {
     telemetry = new TelemetryCollector({ granularity: config.telemetryGranularity });
     telemetry.on('metric', (m) => logger.log('debug', 'metric', m));
     logger.log('info', 'Début de la synchronisation');
-    mainWindow.webContents.send('update-status', 'Vérification des répertoires...');
+    safeSend('update-status', 'Vérification des répertoires...');
 
     await ensureDirectories();
 
-    const cache = await CacheManager.loadCache();
+    let cache = {};
+    try {
+      cache = await CacheManager.loadCache();
+    } catch (err) {
+      logger.log('error', `Cache load failed: ${err.message}`);
+      cache = {};
+    }
 
-    mainWindow.webContents.send('update-status', 'Analyse des fichiers...');
+    safeSend('update-status', 'Analyse des fichiers...');
 
-    const sourceFiles = await scanSourceFiles();
+    let sourceFiles = [];
+    try {
+      sourceFiles = await scanSourceFiles();
+    } catch (err) {
+      logger.log('error', `Scan failed: ${err.message}`);
+      throw err;
+    }
     console.log(`📁 ${sourceFiles.length} fichiers trouvés`);
 
     if (sourceFiles.length === 0) {
-      mainWindow.webContents.send('update-status', '⚠️ Aucun fichier à synchroniser');
-      setTimeout(() => app.quit(), 2000);
+      safeSend('update-status', '⚠️ Aucun fichier à synchroniser');
+      setTimeout(gracefulShutdown, 2000);
       return;
     }
 
@@ -263,7 +308,7 @@ async function performSync() {
         const progress = Math.round((completed / sourceFiles.length) * 100);
         const fileName = path.basename(file);
 
-        mainWindow.webContents.send('update-progress', {
+        safeSend('update-progress', {
           progress,
           current: completed,
           total: sourceFiles.length,
@@ -288,31 +333,41 @@ async function performSync() {
     const reportFile = reportGenerator.generate({ metrics: telemetry.metrics, health: HealthChecker.basicReport(config) });
     logger.log('info', `Rapport généré: ${reportFile}`);
     logger.log('info', `Synchronisation terminée: ${copied} fichiers`);
-    mainWindow.webContents.send('telemetry-summary', telemetry.metrics);
+    safeSend('telemetry-summary', telemetry.metrics);
     CacheManager.evictCache(cache);
     await CacheManager.saveCache(cache);
 
     if (config.executeAfterSync) {
       const appDisplayName = config.appName || path.basename(config.executeAfterSync, '.exe');
-      mainWindow.webContents.send('update-status', `🚀 Lancement: ${appDisplayName}`);
-      setTimeout(() => {
-        console.log(`🚀 Lancement: ${config.executeAfterSync}`);
-        spawn(config.executeAfterSync, [], { detached: true });
-        app.quit();
-      }, 1500);
+      if (fs.existsSync(config.executeAfterSync)) {
+        safeSend('update-status', `🚀 Lancement: ${appDisplayName}`);
+        setTimeout(() => {
+          try {
+            console.log(`🚀 Lancement: ${config.executeAfterSync}`);
+            spawn(config.executeAfterSync, [], { detached: true });
+          } catch (e) {
+            logger.log('error', `Spawn failed: ${e.message}`);
+          }
+          gracefulShutdown();
+        }, 1500);
+      } else {
+        safeSend('update-status', `❌ Exécutable introuvable: ${config.executeAfterSync}`);
+        logger.log('error', `Executable not found: ${config.executeAfterSync}`);
+        setTimeout(gracefulShutdown, 3000);
+      }
     } else {
-      mainWindow.webContents.send('update-status', '✅ Synchronisation terminée');
-      setTimeout(() => app.quit(), 2000);
+      safeSend('update-status', '✅ Synchronisation terminée');
+      setTimeout(gracefulShutdown, 2000);
     }
 
   } catch (error) {
     console.error('❌ Erreur synchronisation:', error);
-    mainWindow.webContents.send('update-status', `❌ Erreur: ${error.message}`);
+    safeSend('update-status', `❌ Erreur: ${error.message}`);
     telemetry.recordError();
     telemetry.finish();
     analytics.addMetrics(telemetry.metrics);
     reportGenerator.generate({ metrics: telemetry.metrics, health: HealthChecker.basicReport(config) });
-    setTimeout(() => app.quit(), 3000);
+    setTimeout(gracefulShutdown, 3000);
   }
 }
 
@@ -328,13 +383,13 @@ app.whenReady().then(async () => {
 
   const health = HealthChecker.basicReport(config);
   logger.log('info', 'Health check', health);
-  mainWindow.webContents.send('health-report', health);
+  safeSend('health-report', health);
 
   NetworkOptimizer.registerTempCleanup(app);
 
   if (hadExistingProcess) {
     setTimeout(() => {
-      mainWindow.webContents.send('update-status', '🔄 Processus précédent fermé...');
+      safeSend('update-status', '🔄 Processus précédent fermé...');
     }, 200);
   }
 
@@ -343,14 +398,12 @@ app.whenReady().then(async () => {
   });
 });
 
-app.on('window-all-closed', () => {
-  app.quit();
-});
+app.on('window-all-closed', gracefulShutdown);
 
 const gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
-  app.quit();
+  gracefulShutdown();
 } else {
   app.on('second-instance', () => {
     if (mainWindow) {

--- a/splash.html
+++ b/splash.html
@@ -229,80 +229,101 @@
     <div class="progress-details" id="progressDetails"></div>
 
     <script>
-        // Vérifier que l'environnement Electron est disponible
-        if (typeof require !== 'undefined') {
+        document.addEventListener('DOMContentLoaded', () => {
+            if (typeof require === 'undefined') {
+                console.error('Environnement Electron non détecté');
+                document.getElementById('status').textContent = 'Erreur: require non disponible';
+                return;
+            }
+
+            let ipcRenderer;
             try {
-                const { ipcRenderer } = require('electron');
-                
-                const statusEl = document.getElementById('status');
-                const progressContainer = document.getElementById('progressContainer');
-                const progressBar = document.getElementById('progressBar');
-                const progressDetails = document.getElementById('progressDetails');
-                const appInfo = document.getElementById('appInfo');
-                const appNameText = document.getElementById('appNameText');
-                const appDescription = document.getElementById('appDescription');
+                ipcRenderer = require('electron').ipcRenderer;
+            } catch (e) {
+                console.error('Erreur chargement IPC:', e);
+                document.getElementById('status').textContent = 'Erreur de communication...';
+                return;
+            }
+
+            const statusEl = document.getElementById('status');
+            const progressContainer = document.getElementById('progressContainer');
+            const progressBar = document.getElementById('progressBar');
+            const progressDetails = document.getElementById('progressDetails');
+            const appInfo = document.getElementById('appInfo');
+            const appNameText = document.getElementById('appNameText');
+            const appDescription = document.getElementById('appDescription');
 
                 // Écouter les informations de l'application
                 ipcRenderer.on('app-info', (event, data) => {
-                    if (data.appName) {
-                        appNameText.textContent = data.appName;
-                        appDescription.textContent = data.appDescription || 'Prêt pour le lancement';
-                        appInfo.classList.add('visible');
-                    } else if (data.executeAfterSync) {
-                        // Fallback: utiliser le nom de l'exe
-                        const exeName = data.executeAfterSync.split('\\').pop().replace('.exe', '');
-                        appNameText.textContent = exeName;
-                        appDescription.textContent = 'Application détectée automatiquement';
-                        appInfo.classList.add('visible');
+                    try {
+                        if (data.appName) {
+                            appNameText.textContent = data.appName;
+                            appDescription.textContent = data.appDescription || 'Prêt pour le lancement';
+                            appInfo.classList.add('visible');
+                        } else if (data.executeAfterSync) {
+                            const exeName = data.executeAfterSync.split('\\').pop().replace('.exe', '');
+                            appNameText.textContent = exeName;
+                            appDescription.textContent = 'Application détectée automatiquement';
+                            appInfo.classList.add('visible');
+                        }
+                    } catch (e) {
+                        console.error('Erreur handler app-info:', e);
                     }
-                    // Si pas d'app à lancer, on cache la section
                 });
 
                 // Écouter les mises à jour de statut
                 ipcRenderer.on('update-status', (event, message) => {
-                    statusEl.textContent = message;
-                    
-                    // Styling conditionnel selon le message
-                    statusEl.className = 'status-text';
-                    if (message.includes('❌') || message.includes('Erreur')) {
-                        statusEl.classList.add('error');
-                    } else if (message.includes('✅') || message.includes('Terminé')) {
-                        statusEl.classList.add('success');
-                    } else if (message.includes('⚠️') || message.includes('fermé') || message.includes('Aucun')) {
-                        statusEl.classList.add('warning');
+                    try {
+                        statusEl.textContent = message;
+
+                        statusEl.className = 'status-text';
+                        if (message.includes('❌') || message.includes('Erreur')) {
+                            statusEl.classList.add('error');
+                        } else if (message.includes('✅') || message.includes('Terminé')) {
+                            statusEl.classList.add('success');
+                        } else if (message.includes('⚠️') || message.includes('fermé') || message.includes('Aucun')) {
+                            statusEl.classList.add('warning');
+                        }
+                    } catch (e) {
+                        console.error('Erreur handler update-status:', e);
                     }
                 });
 
                 // Écouter les mises à jour de progression
                 ipcRenderer.on('update-progress', (event, data) => {
-                    progressContainer.classList.add('visible');
-                    progressBar.style.width = data.progress + '%';
-                    
-                    statusEl.textContent = `Synchronisation en cours...`;
-                    progressDetails.textContent = `${data.current}/${data.total} • ${data.fileName} • ${data.copied} copiés`;
-                    
-                    if (data.progress >= 100) {
-                        statusEl.textContent = `✅ Terminé ! ${data.copied} fichiers synchronisés`;
-                        progressDetails.textContent = '';
+                    try {
+                        progressContainer.classList.add('visible');
+                        progressBar.style.width = data.progress + '%';
+
+                        statusEl.textContent = `Synchronisation en cours...`;
+                        progressDetails.textContent = `${data.current}/${data.total} • ${data.fileName} • ${data.copied} copiés`;
+
+                        if (data.progress >= 100) {
+                            statusEl.textContent = `✅ Terminé ! ${data.copied} fichiers synchronisés`;
+                            progressDetails.textContent = '';
+                        }
+                    } catch (e) {
+                        console.error('Erreur handler update-progress:', e);
                     }
                 });
 
                 ipcRenderer.on('telemetry-summary', (event, data) => {
-                    const summary = `Temps: ${Math.round(data.durationMs/1000)}s • Fichiers: ${data.filesCopied} • Erreurs: ${data.errors}`;
-                    const summaryEl = document.createElement('div');
-                    summaryEl.textContent = summary;
-                    summaryEl.style.fontSize = '12px';
-                    summaryEl.style.marginTop = '8px';
-                    document.body.appendChild(summaryEl);
+                    try {
+                        const summary = `Temps: ${Math.round(data.durationMs/1000)}s • Fichiers: ${data.filesCopied} • Erreurs: ${data.errors}`;
+                        const summaryEl = document.createElement('div');
+                        summaryEl.textContent = summary;
+                        summaryEl.style.fontSize = '12px';
+                        summaryEl.style.marginTop = '8px';
+                        document.body.appendChild(summaryEl);
+                    } catch (e) {
+                        console.error('Erreur handler telemetry-summary:', e);
+                    }
                 });
             } catch (error) {
                 console.error('Erreur IPC:', error);
                 document.getElementById('status').textContent = 'Erreur de communication...';
             }
-        } else {
-            console.error('Environnement Electron non détecté');
-            document.getElementById('status').textContent = 'Erreur: require non disponible';
-        }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- improve process detection when killing existing SyncOtter instances
- add `safeSend` helper with retries and use it for all IPC communications
- add graceful shutdown support and handle SIGINT/SIGTERM
- verify executable existence before spawning external app
- send application info to splash screen
- improve splash screen script robustness and error handling

## Testing
- `npm test` *(fails: Missing script)*