### PR TITLE
Fix ensureDirectories usage in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -120,26 +120,6 @@ async function killExistingProcesses() {
   });
 }
 
-// Créer les répertoires nécessaires
-async function ensureDirectories() {
-  try {
-    if (!await fs.pathExists(config.sourceDirectory)) {
-      console.log(`⚠️  Répertoire source inexistant: ${config.sourceDirectory}`);
-      throw new Error(`Répertoire source introuvable: ${config.sourceDirectory}`);
-    }
-
-    if (!await fs.pathExists(config.targetDirectory)) {
-      console.log(`📁 Création du répertoire de destination: ${config.targetDirectory}`);
-      await fs.ensureDir(config.targetDirectory);
-      console.log('✅ Répertoire de destination créé');
-    }
-
-    return true;
-  } catch (error) {
-    console.error('❌ Erreur répertoires:', error.message);
-    throw error;
-  }
-}
 
 // Charger la configuration externe (optimisé)
 async function loadConfig() {


### PR DESCRIPTION
## Summary
- remove the local `ensureDirectories` function
- rely on the implementation from `shared/sync-core`

## Testing
- `node test-runner.js` *(fails: ErrorRecovery resumeCopy)*
- `node validate.js` *(fails: dependencies missing)*