### PR TITLE
Compile preload.ts reliably

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const electron_1 = require("electron");
+electron_1.contextBridge.exposeInMainWorld('electronAPI', {
+    send: (channel, data) => electron_1.ipcRenderer.send(channel, data),
+    on: (channel, func) => {
+        electron_1.ipcRenderer.on(channel, (event, ...args) => func(...args));
+    }
+});


### PR DESCRIPTION
## Notes
- Added fallback compilation step in `build-app.ps1` if `tsc` is unavailable
- Committed compiled `src/preload.js` for contextBridge export

## Testing
- `node test-runner.js` *(fails: ErrorRecovery resumeCopy - The "cb" argument must be of type function)*