### PR TITLE
Apply security and preload fixes

### DIFF
--- a/ErrorRecovery.js
+++ b/ErrorRecovery.js
@@ -20,7 +20,10 @@ function checkDiskSpace(dir, required) {
   return new Promise((resolve) => {
     let cmd;
     if (process.platform === 'win32') {
-      const drive = path.parse(path.resolve(dir)).root.replace(/\\$/, '');
+      const drive = path
+        .parse(path.resolve(dir))
+        .root.replace(/\\$/, '')
+        .replace(/'/g, "''");
       cmd = `wmic logicaldisk where Caption='${drive}' get FreeSpace /value`;
     } else {
       cmd = `df -Pk \"${dir}\"`;

--- a/logger/AdvancedLogger.js
+++ b/logger/AdvancedLogger.js
@@ -26,7 +26,10 @@ class AdvancedLogger {
       const stats = fs.statSync(this.currentFile);
       if (stats.size >= this.maxSize) {
         const rotated = this.currentFile.replace('.log', `-${Date.now()}.log`);
-        fs.renameSync(this.currentFile, rotated);
+        const temp = this.currentFile + '.rotating';
+        fs.renameSync(this.currentFile, temp);
+        fs.writeFileSync(this.currentFile, '');
+        fs.renameSync(temp, rotated);
       }
     } catch {}
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "fs-extra": "^11.2.0",
     "ajv": "^8.12.0",
+    "proper-lockfile": "^4.1.2",
     "yargs": "^17.7.2",
     "chalk": "^4.1.2",
     "cli-progress": "^3.12.0"

--- a/splash.html
+++ b/splash.html
@@ -230,18 +230,10 @@
 
     <script>
         window.addEventListener('DOMContentLoaded', () => {
-            let ipcRenderer;
-            if (typeof require !== 'undefined') {
-                try {
-                    ({ ipcRenderer } = require('electron'));
-                } catch (err) {
-                    console.error('Chargement IPC échoué:', err);
-                }
-            }
-
-            if (!ipcRenderer) {
-                console.error('Environnement Electron non détecté');
-                document.getElementById('status').textContent = 'Erreur: IPC indisponible';
+            const api = window.electronAPI;
+            if (!api) {
+                console.error('Electron API non disponible');
+                document.getElementById('status').textContent = 'Erreur: API indisponible';
                 return;
             }
 
@@ -253,17 +245,7 @@
             const appNameText = document.getElementById('appNameText');
             const appDescription = document.getElementById('appDescription');
 
-            const safeOn = (channel, handler) => {
-                try {
-                    ipcRenderer.on(channel, (event, data) => {
-                        try { handler(data); } catch (err) { console.error('Handler error', err); }
-                    });
-                } catch (err) {
-                    console.error('Erreur ajout listener', err);
-                }
-            };
-
-            safeOn('app-info', (data) => {
+            api.on('app-info', (data) => {
                 if (data.appName) {
                     appNameText.textContent = data.appName;
                     appDescription.textContent = data.appDescription || 'Prêt pour le lancement';
@@ -276,7 +258,7 @@
                 }
             });
 
-            safeOn('update-status', (message) => {
+            api.on('update-status', (message) => {
                 statusEl.textContent = message;
                 statusEl.className = 'status-text';
                 if (message.includes('❌') || message.includes('Erreur')) {
@@ -288,7 +270,7 @@
                 }
             });
 
-            safeOn('update-progress', (data) => {
+            api.on('update-progress', (data) => {
                 progressContainer.classList.add('visible');
                 progressBar.style.width = data.progress + '%';
                 statusEl.textContent = 'Synchronisation en cours...';
@@ -298,8 +280,7 @@
                     progressDetails.textContent = '';
                 }
             });
-
-            safeOn('telemetry-summary', (data) => {
+            api.on('telemetry-summary', (data) => {
                 const summary = `Temps: ${Math.round(data.durationMs/1000)}s • Fichiers: ${data.filesCopied} • Erreurs: ${data.errors}`;
                 const summaryEl = document.createElement('div');
                 summaryEl.textContent = summary;

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,9 +1,27 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const electron_1 = require("electron");
+const ALLOWED_CHANNELS = [
+    'update-status',
+    'update-progress',
+    'request-shutdown',
+    'health-report',
+    'telemetry-summary'
+];
 electron_1.contextBridge.exposeInMainWorld('electronAPI', {
-    send: (channel, data) => electron_1.ipcRenderer.send(channel, data),
+    send: (channel, data) => {
+        if (ALLOWED_CHANNELS.includes(channel)) {
+            electron_1.ipcRenderer.send(channel, data);
+        }
+    },
+    invoke: (channel, data) => {
+        if (ALLOWED_CHANNELS.includes(channel)) {
+            return electron_1.ipcRenderer.invoke(channel, data);
+        }
+    },
     on: (channel, func) => {
-        electron_1.ipcRenderer.on(channel, (event, ...args) => func(...args));
+        if (ALLOWED_CHANNELS.includes(channel)) {
+            electron_1.ipcRenderer.on(channel, (event, ...args) => func(...args));
+        }
     }
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,8 +1,26 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+const ALLOWED_CHANNELS = [
+  'update-status',
+  'update-progress',
+  'request-shutdown',
+  'health-report',
+  'telemetry-summary'
+];
 contextBridge.exposeInMainWorld('electronAPI', {
-  send: (channel: string, data: any) => ipcRenderer.send(channel, data),
+  send: (channel: string, data: any) => {
+    if (ALLOWED_CHANNELS.includes(channel)) {
+      ipcRenderer.send(channel, data);
+    }
+  },
+  invoke: (channel: string, data: any) => {
+    if (ALLOWED_CHANNELS.includes(channel)) {
+      return ipcRenderer.invoke(channel, data);
+    }
+  },
   on: (channel: string, func: (...args: any[]) => void) => {
-    ipcRenderer.on(channel, (event, ...args) => func(...args));
+    if (ALLOWED_CHANNELS.includes(channel)) {
+      ipcRenderer.on(channel, (event, ...args) => func(...args));
+    }
   }
 });

--- a/test-runner.js
+++ b/test-runner.js
@@ -45,6 +45,12 @@ test('CacheManager atomic operations', async () => {
   fs.unlinkSync(tmp);
 });
 
+test('CacheManager handles corrupted cache', async () => {
+  fs.writeFileSync(CacheManager.CACHE_PATH, 'invalid json');
+  const cache = await CacheManager.loadCache();
+  if (Object.keys(cache).length !== 0) throw new Error('cache should be empty');
+});
+
 // NetworkOptimizer tests
 
 test('NetworkOptimizer isUNCPath', () => {


### PR DESCRIPTION
## Summary
- expose `invoke` in the preload scripts
- migrate splash page to use `electronAPI`

## Testing
- `npm run compile-preload` *(fails: Cannot find module 'electron')*
- `node test-runner.js` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_b_683d498f77848326a3d89117b888c030