### PR TITLE
Fix ajv conflict by removing overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,6 @@
     "chalk": "^4.1.2",
     "cli-progress": "^3.12.0"
   },
-  "overrides": {
-    "ajv": "^8.12.0"
-  },
-  "resolutions": {
-    "ajv": "^8.12.0"
-  },
   "build": {
     "appId": "com.syncotter.app",
     "productName": "SyncOtter",


### PR DESCRIPTION
## Summary
- remove `overrides` and `resolutions` that forced ajv 8.12.0

## Testing
- `node test-runner.js` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_b_683d53fa9ba48326b5423c1f285f7a12