### PR TITLE
Fix path check and UTF-8 BOM for build script

### DIFF
--- a/build-indi-suivi-refonte.ps1
+++ b/build-indi-suivi-refonte.ps1
@@ -1,4 +1,4 @@
-# Script de build refondé pour Indi-Suivi - Inspiré de build-app-improved-upx.ps1 
+﻿# Script de build refondé pour Indi-Suivi - Inspiré de build-app-improved-upx.ps1 
 param(
     [switch]$Clean = $true,
     [switch]$InstallDeps = $false,
@@ -188,7 +188,7 @@ try {
     }
     
     # Vérifier les fichiers critiques
-    $criticalFiles = @("package.json", "src\main.js")
+    $criticalFiles = @("package.json", "main.js")
     foreach ($file in $criticalFiles) {
         if (-not (Test-Path $file)) {
             throw "Fichier critique manquant: $file"
@@ -266,8 +266,8 @@ try {
     npx vite build --config vite.main.config.ts --mode production
     if ($LASTEXITCODE -ne 0) {
         Write-ColorText "   ❌ Échec du build main.js, utilisation du fallback" $Yellow
-        if (Test-Path "src\main.js") {
-            Copy-Item "src\main.js" ".vite\build\main.js" -Force
+        if (Test-Path "main.js") {
+            Copy-Item "main.js" ".vite\build\main.js" -Force
             Write-ColorText "   ✓ Fallback: main.js copié directement" $Yellow
         } else {
             throw "Impossible de construire main.js"


### PR DESCRIPTION
## Summary
- fix critical file check for `main.js`
- update fallback path when build of `main.js` fails
- ensure the PowerShell script is encoded with UTF-8 BOM

## Testing
- `node test-runner.js` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_b_683d5cf725408326ba862b8c1a2c1b76