### PR TITLE
Fix build script root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ npm start
 
 # 4. Compiler l'exécutable
 .\build-indi-suivi-refonte.ps1
+> **Note** : lancez ce script depuis le dossier `SyncOtter` pour que les chemins soient correctement résolus.
 ```
 
 ### Compilation express :

--- a/build-indi-suivi-refonte.ps1
+++ b/build-indi-suivi-refonte.ps1
@@ -147,7 +147,7 @@ function Invoke-IndiSuiviOptimizations {
 }
 
 # Obtenir le répertoire racine du projet
-$projectRoot = Split-Path -Parent $PSScriptRoot
+$projectRoot = $PSScriptRoot
 Write-ColorText "🚀 Build Indi-Suivi - Projet: $projectRoot" $Cyan
 
 # Se déplacer dans le répertoire racine


### PR DESCRIPTION
## Summary
- clarify running path for build script in README

## Testing
- `node test-runner.js` *(fails: Cannot find module 'fs-extra')*


------
https://chatgpt.com/codex/tasks/task_b_683d5dc5c98c8326a5671dc00a4d1096