### PR TITLE
Prevent zombie Electron processes and improve cleanup

### DIFF
--- a/ErrorRecovery.js
+++ b/ErrorRecovery.js
@@ -77,16 +77,16 @@ async function resumeCopy(src, dest) {
     written = destStat.size;
   }
 
-  const read = fs.createReadStream(src, { start: written });
-  const write = fs.createWriteStream(dest, { flags: written ? 'r+' : 'w', start: written });
+  let read = fs.createReadStream(src, { start: written });
+  let write = fs.createWriteStream(dest, { flags: written ? 'r+' : 'w', start: written });
 
   try {
     await new Promise((resolve, reject) => {
       read.pipe(write).on('finish', resolve).on('error', reject);
     });
   } finally {
-    read.close();
-    write.close();
+    if (read && !read.destroyed) read.destroy();
+    if (write && !write.destroyed) write.destroy();
   }
 
   const final = await fs.stat(dest);


### PR DESCRIPTION
## Summary
- add `scheduleShutdown` and `forceCleanShutdown` to ensure timers and child processes are cleaned up
- close streams correctly when resuming transfers
- add `transferFileWithCleanup` helper
- track active network operations and kill them on shutdown
- implement `Stop-ElectronProcesses` in build script

## Testing
- `node test-runner.js` *(fails: Cannot find module 'fs-extra')*
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_683d5fe901b88326b65ba80ff40409d2