### PR TITLE
Disable code signing on Windows

### DIFF
--- a/build-indi-suivi-refonte.ps1
+++ b/build-indi-suivi-refonte.ps1
@@ -449,6 +449,7 @@ try {
         $builderArgs = @(
             "--win",
             "--publish", "never",
+            "--config.win.sign=false",
             "--config.compression=maximum",
             "--config.nsis.oneClick=false",
             "--config.nsis.allowElevation=true",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
             "x64"
           ]
         }
-      ]
+      ],
+      "sign": false,
+      "verifyUpdateCodeSignature": false
     },
     "files": [
       "main.js",


### PR DESCRIPTION
## Summary
- disable windows code signing in build script
- disable code signing in electron-builder config

## Testing
- `node validate.js --dry-run` *(fails: dependencies not installed)*
- `node test-runner.js` *(fails: cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_b_683d6c6faaf08326b12f97b35b733221