### PR TITLE
Enhance pkg build script with extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ cp package-pkg.json package.json
 ```
 Résultat : `pkg-dist/SyncOtter-Single.exe`
 
+### Build optimisé avec UPX
+```powershell
+./build-pkg.ps1 -UPX -Test
+```
+
 ### Lancement optimisé :
 ```powershell
 # Lancement direct (gestion auto des processus)


### PR DESCRIPTION
## Summary
- add UPX and startup test options to `build-pkg.ps1`
- document the new options in the README

## Testing
- `node validate.js` *(fails: cannot read package-lock.json and missing dependencies)*
- `node test-runner.js` *(fails: cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_b_683d7a083ad88326b4c49d63682afeee