### PR TITLE
Fix PKG build cleanup

### DIFF
--- a/build-pkg.ps1
+++ b/build-pkg.ps1
@@ -46,8 +46,15 @@ try {
 
     # Nettoyage avancé de node_modules
     Write-Col "🧹 Nettoyage avancé de node_modules" $Yellow
-    Get-ChildItem -Path node_modules -Recurse -Directory -Filter test, tests, __tests__, doc, docs 2>$null | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-    Get-ChildItem -Path node_modules -Recurse -Include *.md, *.markdown, *.ts 2>$null | Remove-Item -Force -ErrorAction SilentlyContinue
+
+    # Supprimer les dossiers de test et de documentation
+    Get-ChildItem -Path node_modules -Recurse -Directory 2>$null | Where-Object {
+        $_.Name -in @('test','tests','__tests__','doc','docs')
+    } | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
+    # Supprimer certains fichiers inutiles
+    Get-ChildItem -Path node_modules -Recurse -File -Include '*.md','*.markdown','*.ts','*.map' 2>$null |
+        Remove-Item -Force -ErrorAction SilentlyContinue
 
     $compressArg = if ($Compress) { '--compress Brotli' } else { '' }
     $pkgCmd = "pkg main-cli.js --targets $Target $compressArg --no-bytecode --output pkg-dist/SyncOtter-Single.exe"


### PR DESCRIPTION
## Summary
- ensure node_modules cleanup uses Where-Object so the script runs

## Testing
- `node validate.js` *(fails: cannot read package-lock.json and missing dependencies)*
- `node test-runner.js` *(fails: cannot find module 'fs-extra')*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_683d7fea03188326997c3a549bd2eb64