### PR TITLE
Fix pkg build script

### DIFF
--- a/build-pkg.ps1
+++ b/build-pkg.ps1
@@ -60,7 +60,14 @@ try {
     $pkgCmd = "pkg main-cli.js --targets $Target $compressArg --no-bytecode --output pkg-dist/SyncOtter-Single.exe"
     Write-Col $pkgCmd $Gray
     Invoke-Expression $pkgCmd
-    if ($LASTEXITCODE -ne 0) { throw 'pkg a échoué' }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw 'pkg a échoué'
+    }
+
+    if (-not (Test-Path 'pkg-dist/SyncOtter-Single.exe')) {
+        throw "pkg n'a pas généré pkg-dist/SyncOtter-Single.exe"
+    }
 
     $exe = Get-Item 'pkg-dist/SyncOtter-Single.exe'
     $size = [Math]::Round($exe.Length / 1MB, 2)


### PR DESCRIPTION
## Summary
- ensure `build-pkg.ps1` fails if pkg doesn't create the executable

## Testing
- `node validate.js --dry-run`

------
https://chatgpt.com/codex/tasks/task_b_683d813ec47883269b7b7725e42cf28d