### PR TITLE
Use local Node version for pkg build

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ npm start
 ### Build single-file avec PKG
 ```powershell
 cp package-pkg.json package.json
+# la cible Node est déterminée à partir de la version installée
+# on peut la surcharger via $env:PKG_NODE_TARGET
 ./build-pkg.ps1
 ```
 Résultat : `pkg-dist/SyncOtter-Single.exe`

--- a/build-pkg.ps1
+++ b/build-pkg.ps1
@@ -1,11 +1,29 @@
 param(
     [switch]$Clean = $true,
     [switch]$Compress = $true,
-    [string]$Target = 'node18-win-x64',
+    [string]$Target,
     [switch]$UPX = $false,
     [switch]$Test = $false,
     [string]$UPXPath = 'upx'
 )
+
+function Get-DefaultNodeTarget {
+    $envTarget = $env:PKG_NODE_TARGET
+    if ($envTarget) { return $envTarget }
+    try {
+        $ver = (node -v 2>$null).Trim()
+        if ($LASTEXITCODE -eq 0 -and $ver) {
+            if ($ver.StartsWith('v')) { $ver = $ver.Substring(1) }
+            $major = $ver.Split('.')[0]
+            return "node$major-win-x64"
+        }
+    } catch {}
+    return 'node18-win-x64'
+}
+
+if (-not $Target) {
+    $Target = Get-DefaultNodeTarget
+}
 
 $Cyan = [ConsoleColor]::Cyan
 $Green = [ConsoleColor]::Green


### PR DESCRIPTION
## Summary
- detect Node version from environment when building with `pkg`
- mention `PKG_NODE_TARGET` in docs

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_683d831d63d48326aa5e03dde9f1869b