### PR TITLE
Handle Node 20 in build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ npm start
 cp package-pkg.json package.json
 # la cible Node est déterminée à partir de la version installée
 # on peut la surcharger via $env:PKG_NODE_TARGET
+# **Note :** pkg 5.x ne gère pas encore Node.js 20. Si vous utilisez Node 20 ou
+# supérieur, le script retombera automatiquement sur `node18-win-x64`. Vous
+# pouvez aussi définir manuellement `PKG_NODE_TARGET=node18-win-x64` pour éviter
+# l'avertissement.
 ./build-pkg.ps1
 ```
 Résultat : `pkg-dist/SyncOtter-Single.exe`

--- a/build-pkg.ps1
+++ b/build-pkg.ps1
@@ -14,8 +14,14 @@ function Get-DefaultNodeTarget {
         $ver = (node -v 2>$null).Trim()
         if ($LASTEXITCODE -eq 0 -and $ver) {
             if ($ver.StartsWith('v')) { $ver = $ver.Substring(1) }
-            $major = $ver.Split('.')[0]
-            return "node$major-win-x64"
+            $major = [int]$ver.Split('.')[0]
+
+            # pkg 5.x ne supporte que Node 16/18
+            if ($major -ge 16 -and $major -le 18) {
+                return "node$major-win-x64"
+            }
+
+            Write-Col "⚠️ Node $major non supporté par pkg, fallback vers node18" $Yellow
         }
     } catch {}
     return 'node18-win-x64'


### PR DESCRIPTION
## Summary
- warn and fallback to `node18` when pkg can't handle Node 20
- document the fallback in the README

## Testing
- `node validate.js --dry-run` *(fails: dependencies not installed)*
- `node test-runner.js` *(fails: cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_b_683d84ebe54083268a2c04072e320ea0