### PR TITLE
Fix PowerShell build script

### DIFF
--- a/build-deno.ps1
+++ b/build-deno.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [switch]$Clean = $true
 )
 
@@ -28,9 +28,9 @@ try {
     }
 
     Write-Col "🏗️ Compilation avec Deno..." $Yellow
-    & deno compile \
-        --output "deno-dist/SyncOtter-Single.exe" \
-        --allow-read --allow-write --allow-run --allow-env \
+    & deno compile `
+        --output "deno-dist/SyncOtter-Single.exe" `
+        --allow-read --allow-write --allow-run --allow-env `
         src/deno-main.ts
 
     if ($LASTEXITCODE -ne 0) { throw 'deno compile a échoué' }


### PR DESCRIPTION
## Summary
- fix line continuations in `build-deno.ps1`
- save `build-deno.ps1` with UTF-8 BOM encoding

## Testing
- `deno --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ecc87b3648326a298015fa7ea1d39