### PR TITLE
Fix splash resources and add silent build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ SyncOtter est un outil de synchronisation simplifié pouvant être compilé avec
 ## 🚀 Utilisation rapide
 
 1. Placez votre configuration dans `config.json` à côté de l'exécutable.
-2. Compilez l'outil :
+2. Compilez l'outil (optionnellement avec `-NoConsole` pour masquer la fenêtre terminal) :
    ```powershell
-   ./build-deno.ps1
+   ./build-deno.ps1 -NoConsole
    ```
-   Le binaire est généré dans `deno-dist/SyncOtter-Single.exe`.
-3. Lancez l'exécutable pour démarrer la synchronisation.
+   Le binaire et le dossier `web` sont générés dans `deno-dist`.
+3. Copiez `config.json` **et** le dossier `web` à côté de l'exécutable.
+4. Lancez l'exécutable pour démarrer la synchronisation.
 
 ## Exemple de `config.json`
 

--- a/build-deno.ps1
+++ b/build-deno.ps1
@@ -381,6 +381,12 @@ deno run --allow-read --allow-write --allow-run --allow-env "%~dp0SyncOtter-Bund
 
     # Résultat
     Write-Col "`n✅ Build terminé : 'deno-dist/$outputName'" $Green
+
+    # Copier les ressources du splash screen pour la version compilée
+    if (Test-Path 'web') {
+        Copy-Item -Path 'web' -Destination 'deno-dist' -Recurse -Force
+        Write-Col "📂 Dossier 'web' copié dans deno-dist" $Cyan
+    }
     
     # Créer une version sans console si demandé (Windows uniquement)
     if ($NoConsole -and $outputName.EndsWith('.exe') -and (Test-Path "deno-dist/$outputName")) {


### PR DESCRIPTION
## Summary
- copy the `web` folder into `deno-dist` during build so the splash screen opens
- document the `-NoConsole` option and copying of the `web` folder

## Testing
- `deno --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ef27d8a0c8326ad09aa8371dc54a3